### PR TITLE
Import Rails from Rails UJS

### DIFF
--- a/app/assets/javascripts/comfy/admin/cms/sortable_list.js
+++ b/app/assets/javascripts/comfy/admin/cms/sortable_list.js
@@ -1,7 +1,7 @@
 import Sortable from "sortablejs";
+import Rails from "@rails/ujs";
 
 (() => {
-  const Rails = window.Rails;
   const DATA_ID_ATTRIBUTE = "data-id";
 
   const sortableStore = {


### PR DESCRIPTION
### Summary

sortable_list.js fails when we try to drag an item (window.Rails is undefined).
To fix, we import it like it's done in wysiwyg.js.
